### PR TITLE
Improved system configuration structure

### DIFF
--- a/Kernel/Config/Files/XML/ITSMCore.xml
+++ b/Kernel/Config/Files/XML/ITSMCore.xml
@@ -75,7 +75,12 @@
         <Navigation>Core::ITSMCore</Navigation>
         <Value>
             <Hash>
-                <Item Key="DependsOn" Translatable="1">Both</Item>
+                <DefaultItem ValueType="Select">
+                    <Item ValueType="Option" Value="Both" Translatable="1">Both</Item>
+                    <Item ValueType="Option" Value="Source" Translatable="1">Source</Item>
+                    <Item ValueType="Option" Value="Target" Translatable="1">Target</Item>
+                </DefaultItem>
+                <Item Key="DependsOn" SelectedID="Both"></Item>
             </Hash>
         </Value>
     </Setting>


### PR DESCRIPTION
Hi @UdoBretz 
As the direction can only be 'Source', 'Target', or 'Both', this structure is better. This prevents users from set a wrong value for the setting.